### PR TITLE
Add `slow-mode` capability when slow mode is enabled

### DIFF
--- a/src/server/config.rb
+++ b/src/server/config.rb
@@ -11,8 +11,10 @@ post '/config/cooldown' do
   if params[:enabled].to_s.casecmp('true').zero?
     channel['channel']['cooldown'] = params[:duration].to_i
     channel['channel']['own_capabilities'].delete('skip-slow-mode')
+    channel['channel']['own_capabilities'] |= ['slow-mode']
   else
     channel['channel']['cooldown'] = nil
+    channel['channel']['own_capabilities'].delete('slow-mode')
   end
 
   halt(200)


### PR DESCRIPTION
The `/config/cooldown` endpoint set the channel cooldown and removed `skip-slow-mode`, but never added the `slow-mode` own capability.

The real backend grants `slow-mode` when `cooldown > 0` and the user cannot skip it. Clients that gate slow mode on that capability (Android) never saw it as active, so the composer cooldown UI did not show. iOS only checks `cooldown > 0` and the absence of `skip-slow-mode`, so it was unaffected.

This adds `slow-mode` on enable and removes it on disable, matching the backend. Verified by running the Android compose-sample `SlowModeTests` e2e against this driver.
