### PR TITLE
Add create-mention capability to channel fixtures

### DIFF
--- a/src/jsons/http_add_member.json
+++ b/src/jsons/http_add_member.json
@@ -92,6 +92,7 @@
       "cast-poll-vote",
       "connect-events",
       "create-attachment",
+      "create-mention",
       "delete-any-message",
       "delete-channel",
       "delete-own-message",

--- a/src/jsons/http_channel_creation.json
+++ b/src/jsons/http_channel_creation.json
@@ -91,6 +91,7 @@
       "cast-poll-vote",
       "connect-events",
       "create-attachment",
+      "create-mention",
       "delete-any-message",
       "delete-channel",
       "delete-own-message",

--- a/src/jsons/http_channels.json
+++ b/src/jsons/http_channels.json
@@ -93,6 +93,7 @@
           "cast-poll-vote",
           "connect-events",
           "create-attachment",
+          "create-mention",
           "delete-any-message",
           "delete-channel",
           "delete-own-message",


### PR DESCRIPTION
## Why

The Android SDK now gates user mention autocomplete behind the `create-mention` channel capability (see [stream-chat-android#6503](https://github.com/GetStream/stream-chat-android/pull/6503)). The composer only resolves user suggestions when `create-mention` is present in the channel's `own_capabilities`.

The channel fixtures here predate that capability, so the suggestion list never appears and the mention E2E tests (`test_mentionsView`, `test_userFillsTheComposerMentioningParticipantThroughMentionsView`) time out.

## What

Adds `create-mention` to `own_capabilities` in the three channel fixtures:
- `http_channels.json`
- `http_add_member.json`
- `http_channel_creation.json`

Verified green against stream-chat-android#6503 by pointing its E2E run at this branch.