### PR TITLE
Include show_in_channel thread replies in the channel query response

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -418,7 +418,11 @@ def paginate_message_list(params:, request_body:)
   messages = json['messages']
   return channel.to_s unless messages && messages['limit']
 
-  message_list = $message_list.select { |msg| msg['cid'] == "#{params[:channel_type]}:#{params[:channel_id]}" && msg['parent_id'].nil? }
+  # Match the backend's channel message predicate: (parent_id IS NULL) OR (show_in_channel = true).
+  # Thread replies sent also to the channel must be part of the channel query response.
+  message_list = $message_list.select do |msg|
+    msg['cid'] == "#{params[:channel_type]}:#{params[:channel_id]}" && (msg['parent_id'].nil? || msg['show_in_channel'])
+  end
   paginated_messages = mock_message_pagination(
     message_list: message_list,
     limit: messages['limit'].to_i,


### PR DESCRIPTION
### What

The channel query response (`paginate_message_list`) only returned messages with `parent_id == nil`, which drops thread replies sent also to the channel. The backend's channel message predicate is `(parent_id IS NULL) OR (show_in_channel = true)`, so those replies belong in the response.

### Why it matters

This surfaced as the flaky `test_threadReplyIsRemovedEverywhere_whenParticipantRemovesItFromChannel` on Android (AND-1303). The chain, reconstructed from the per-attempt artifacts of the 2026-07-13 nightly:

1. The WebSocket drops mid-test on a loaded CI emulator and the client reconnects.
2. As part of recovery, the client re-queries the channel.
3. The response omits the also-in-channel reply, so the client (correctly, given the data) removes it from state, wiping the deleted-message placeholder the test was asserting. The placeholder was visible in the UI for 110ms before the response arrived.

The client behaved correctly; the response was the lie. Without a mid-test reconnect there is no re-query, which is why the test only flakes under CI load.

### Testing

Against a local instance: seeded a regular message, a thread reply with `thread_and_channel=true`, and a thread-only reply, then `POST /channels/messaging/{id}/query`:

- the also-in-channel reply is now in `messages` (the fix)
- the thread-only reply stays excluded (no regression)
- regular messages unaffected
