### PR TITLE
Add server-side channel triggers for truncation and member updates

### DIFF
--- a/src/robots/chat.rb
+++ b/src/robots/chat.rb
@@ -97,3 +97,16 @@ post '/truncate_channel' do
   truncate_channel(channel_id: $current_channel_id, request_body: request_body)
   ''
 end
+
+# Adds or removes a member on the current channel as a server-side action, reusing
+# the same helper as the client-initiated channel update endpoint. The app under test
+# receives the `member.added`/`member.removed` and `channel.updated` websocket events.
+post '/add_member' do
+  update_members(channel_id: $current_channel_id, request_body: { add_members: [params[:user_id]] }.to_json)
+  ''
+end
+
+post '/remove_member' do
+  update_members(channel_id: $current_channel_id, request_body: { remove_members: [params[:user_id]] }.to_json)
+  ''
+end

--- a/src/robots/chat.rb
+++ b/src/robots/chat.rb
@@ -88,3 +88,12 @@ post '/delay_messages' do
   $delay_messages = params[:delay].to_i.positive? ? params[:delay].to_i : 5
   ''
 end
+
+# Truncates the current channel as a server-side action, reusing the same helper
+# as the client-initiated truncate endpoint. The app under test only receives the
+# `channel.truncated` websocket event (and the system message when requested).
+post '/truncate_channel' do
+  request_body = params[:with_message] == 'true' ? '{"message":{}}' : ''
+  truncate_channel(channel_id: $current_channel_id, request_body: request_body)
+  ''
+end


### PR DESCRIPTION
### Goal

The Android compose sample has no debug menu, so the iOS e2e scenarios that trigger channel truncation and member changes through the app UI need a server-side trigger instead. This adds three routes that reuse the existing helpers, so the app under test receives the same websocket events as with the client-initiated endpoints:

- `POST /truncate_channel?with_message=<bool>` reuses `truncate_channel` (sends `channel.truncated`, plus the system message when requested)
- `POST /add_member?user_id=<id>` and `POST /remove_member?user_id=<id>` reuse `update_members` (send `member.added`/`member.removed` and `channel.updated`)

### Testing

Driven by the ported Android e2e tests in GetStream/stream-chat-android (channel truncation, member removal, and read-events scenarios), all verified locally against this branch. The truncation tests pass end to end; the member routes deliver the events correctly (the tests that consume them are gated on Android SDK fixes, tracked separately).
