### PR TITLE
Add v2 attachment upload routes

### DIFF
--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -103,6 +103,18 @@ post '/channels/messaging/:channel_id/file' do
   { file: file }.to_s
 end
 
+# Send image (v2)
+post '/api/v2/chat/channels/messaging/:channel_id/image' do
+  file = test_asset('image')
+  { file: file }.to_s
+end
+
+# Send file (v2)
+post '/api/v2/chat/channels/messaging/:channel_id/file' do
+  file = request.content_type.include?('video') ? test_asset('video') : test_asset('file')
+  { file: file }.to_s
+end
+
 # Send reaction
 post '/messages/:message_id/reaction' do
   create_reaction(type: JSON.parse(request.body.read)['reaction']['type'], message_id: params[:message_id])


### PR DESCRIPTION
Adds v2 attachment upload routes so the iOS SDK's OpenAPI-migrated upload endpoints resolve against the mock server:

- `POST /api/v2/chat/channels/messaging/:channel_id/image`
- `POST /api/v2/chat/channels/messaging/:channel_id/file`

They mirror the existing handlers; the prefix-less v1 routes are kept so older SDK versions keep passing.

Related: [IOS-1833](https://linear.app/stream/issue/IOS-1833/openapi-migrate-attachment-upload-and-delete-endpoints)