### PR TITLE
Add Android push notification delivery

### DIFF
--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -111,6 +111,7 @@ end
 ###### PUSH NOTIFICATIONS ######
 
 ### Parameters
+# `platform`: String - `ios` (default) or `android`
 # `title`: String - Push notification title
 # `body`: String - Push notification body
 # `rest`: String - Rest of the payload (empty, null, incorrect_type, incorrect_data, invalid)
@@ -119,8 +120,10 @@ end
 # `component`: String - Broadcast receiver component of the test app (Android)
 
 post '/participant/push' do
-  return android_push if params[:component]
+  params[:platform] == 'android' ? android_push : ios_push
+end
 
+def ios_push
   badge = 1
   mutable_content = 1
   category = 'stream.chat'
@@ -195,7 +198,7 @@ post '/participant/push' do
 
   push_data_file = 'push_payload.json'
   File.write(push_data_file, payload)
-  puts `xcrun simctl push #{params['udid']} #{params['bundle_id']} #{push_data_file}`
+  puts(`xcrun simctl push #{params['udid']} #{params['bundle_id']} #{push_data_file}`)
 end
 
 # Delivers the push payload to the Android test app with an adb broadcast. The receiver

--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -239,7 +239,7 @@ def android_push
   end
 
   extras = data.compact.map { |key, value| "--es #{key} '#{value}'" }.join(' ')
-  puts `adb shell am broadcast -n #{params[:component]} #{extras}`
+  puts(`adb shell am broadcast -n #{params[:component]} #{extras}`)
 end
 
 ###### REACTIONS ######

--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -114,10 +114,13 @@ end
 # `title`: String - Push notification title
 # `body`: String - Push notification body
 # `rest`: String - Rest of the payload (empty, null, incorrect_type, incorrect_data, invalid)
-# `bundle_id`: String - Test app bundle id
-# `udid`: String - Device udid
+# `bundle_id`: String - Test app bundle id (iOS)
+# `udid`: String - Device udid (iOS)
+# `component`: String - Broadcast receiver component of the test app (Android)
 
 post '/participant/push' do
+  return android_push if params[:component]
+
   badge = 1
   mutable_content = 1
   category = 'stream.chat'
@@ -193,6 +196,50 @@ post '/participant/push' do
   push_data_file = 'push_payload.json'
   File.write(push_data_file, payload)
   puts `xcrun simctl push #{params['udid']} #{params['bundle_id']} #{push_data_file}`
+end
+
+# Delivers the push payload to the Android test app with an adb broadcast. The receiver
+# feeds it into the client SDK pipeline, whose validator requires `version`, `sender`,
+# a supported `type`, `message_id`, and `cid` (or the `channel_id` and `channel_type` pair).
+# The `rest` degradations mirror the iOS semantics against that contract: optional keys
+# degrade without dropping the push, `invalid_*` break a required key so the push is dropped.
+def android_push
+  data = {
+    version: 'v2',
+    sender: 'stream.chat',
+    type: MessageEventType.new,
+    message_id: last_message_id,
+    cid: "messaging:#{$current_channel_id}",
+    channel_id: $current_channel_id,
+    channel_type: 'messaging',
+    title: params[:title],
+    body: params[:body]
+  }
+
+  case params[:rest]
+  when 'null'
+    data.delete(:title)
+    data.delete(:body)
+  when 'empty'
+    data[:title] = ''
+    data[:body] = ''
+  when 'incorrect_type'
+    data[:title] = '42'
+    data[:badge] = 'test'
+    data[:'mutable-content'] = 'test'
+  when 'incorrect_data'
+    data[:badge] = '-1'
+    data[:'mutable-content'] = '-1'
+  when 'invalid_version'
+    data[:version] = '42'
+  when 'invalid_sender'
+    data[:sender] = ''
+  when 'invalid_type'
+    data[:type] = 'bogus'
+  end
+
+  extras = data.compact.map { |key, value| "--es #{key} '#{value}'" }.join(' ')
+  puts `adb shell am broadcast -n #{params[:component]} #{extras}`
 end
 
 ###### REACTIONS ######


### PR DESCRIPTION
### Goal

The Android e2e suite needs to deliver push notifications, which no client network path carries (they arrive through the OS). The iOS side of `/participant/push` uses `xcrun simctl push`, which only works on iOS simulators. This adds an Android delivery branch to the same endpoint.

### Implementation

When `/participant/push` receives a `component` param (the app's broadcast receiver), it builds the Stream FCM data payload (`version`, `sender`, `type`, `message_id`, `cid`, `channel_id`, `channel_type`, `title`, `body`) and delivers it with `adb shell am broadcast`. The receiver in the app under test feeds it into the client SDK's real validation and notification path.

The `rest` degradations mirror the iOS semantics against the Android payload contract: `null` and `empty` degrade the optional title and body while keeping the routing keys valid (so the push still appears), `incorrect_type` and `incorrect_data` add junk badge fields, and `invalid_version`/`invalid_sender`/`invalid_type` break a required key so the client validator drops the push. The iOS branch is unchanged.

### Testing

Driven by the ported Android push notification e2e tests (`PushNotificationTests` in GetStream/stream-chat-android), all 7 verified locally against this branch on a Pixel 8 API 35 emulator.
