### PR TITLE
Persist the truncation system message

### DIFF
--- a/src/helpers/channels.rb
+++ b/src/helpers/channels.rb
@@ -64,6 +64,11 @@ def truncate_channel(channel_id:, request_body:)
     message_id = json['message']['id'] || unique_id
     message_text = json['message']['text'] || 'Channel truncated'
 
+    # Persist the system message (track_message: true) so it survives a channel re-query.
+    # The backend keeps the truncation system message, so a client that re-watches the
+    # channel after `channel.truncated` gets it back. Without persistence the re-query
+    # rebuilds `channel['messages']` from an empty `$message_list` and wipes the message
+    # the client just received over the websocket, which flakes the assertion.
     truncated_message = mock_message(
       Mocks.message['message'],
       message_type: MessageType.system,
@@ -73,7 +78,7 @@ def truncate_channel(channel_id:, request_body:)
       user: truncated_by,
       created_at: truncated_at,
       updated_at: truncated_at,
-      track_message: false
+      track_message: true
     )
 
     response['message'] = truncated_message


### PR DESCRIPTION
### Goal

The truncation e2e test (`test_messageList_and_channelPreview_AreUpdatedWhenChannelTruncatedWithMessage`) flakes because the mock discards the truncation system message. After `channel.truncated`, the client re-watches the channel; the mock rebuilds the channel from an empty message list and wipes the system message the client just received over the websocket, so the assertion times out.

Resolves AND-1313

### Implementation

`truncate_channel` created the system message with `track_message: false`, so it was only broadcast over the websocket and never stored. The backend keeps the truncation system message, so a re-query returns it. This changes it to `track_message: true`, so the message persists in `$message_list`, and both the channel query (`paginate_message_list`) and the channel list preview (`sync_channels`), which rebuild from `$message_list`, return it.

### Testing

HTTP before/after against a local server: before the fix, a channel query after truncate-with-message returns 0 messages; after, it returns the "Channel truncated" system message and the channel list preview shows it. Rubocop clean.
