### PR TITLE
Add a /ws/status endpoint exposing the WebSocket connection status

### DIFF
--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -12,6 +12,11 @@ get '/connect' do
   end
 end
 
+# Show WebSocket connection status
+get '/ws/status' do
+  { connected: !$ws.nil? }.to_json
+end
+
 # Synchronize
 post '/sync' do
   { events: [] }.to_json


### PR DESCRIPTION
### Goal

The Android offline e2e tests background the app and then have the participant send a message that must not be delivered live. The SDK keeps the WebSocket open for a short period after the app goes to background, so the tests currently race against the disconnect. To make them deterministic, the tests need a way to wait until the client socket is actually closed.

Part of AND-1325

### Implementation

The server already tracks the client socket in `$ws` and resets it to `nil` in the `on(:close)` handler. The new `GET /ws/status` endpoint returns `{"connected": true|false}` based on that handle. The change is additive and does not touch any existing endpoint or event flow, so other platforms and branches using this mock are unaffected.

### Testing

Ran the two updated Android tests (`test_offlineMessageInTheMessageList` and `test_offlineRecoveryWithinSession`) locally against this server version. The per-test request logs show `GET /ws/status` returning `connected: false` before `POST /participant/message`, no live WebSocket delivery, and the message arriving on reconnect through the channel query. Rubocop is clean.
