### PR TITLE
Replay missed events in the /sync endpoint

### DIFF
--- a/src/helpers/channels.rb
+++ b/src/helpers/channels.rb
@@ -57,7 +57,7 @@ def truncate_channel(channel_id:, request_body:)
   ws_response['created_at'] = truncated_at
   ws_response['user'] = truncated_by
   ws_response['channel'] = response['channel']
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
 
   # If message provided in request, create system message
   if json['message']

--- a/src/helpers/events.rb
+++ b/src/helpers/events.rb
@@ -6,7 +6,54 @@ def send_event_ws(response)
   ws_response['created_at'] = response['created_at']
   ws_response['type'] = response['event']['type']
   ws_response['parent_id'] = response['parent_id'] if response['parent_id']
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
+end
+
+# Event types the real backend persists for /sync replay. Transient events
+# (typing, read, member, draft) are broadcast live but never replayed.
+SYNC_REPLAYED_EVENT_TYPES = %w[
+  channel.created
+  channel.updated
+  channel.deleted
+  channel.hidden
+  channel.visible
+  channel.truncated
+  notification.added_to_channel
+  notification.removed_from_channel
+  message.new
+  message.updated
+  message.deleted
+  message.undeleted
+  reaction.new
+  reaction.updated
+  reaction.deleted
+].freeze
+
+# Sends a websocket event and records a snapshot of it so POST /sync can replay it if the client
+# missed it while its socket was down. The live event is sent untouched; only the recorded copy
+# is stamped with the broadcast time (sub-second, matching the backend). This matters because the
+# client sorts sync'd events by `created_at` and rejects the batch when the newest equals its
+# `last_sync_at`, so a replayed delete or edit must carry its occurrence time rather than the
+# deleted message's original `created_at`, which would equal `last_sync_at` and be dropped. The
+# snapshot is taken at send time so a later in-place mutation of the message cannot change it.
+def broadcast_event(event)
+  if event.kind_of?(Hash) && event['cid'] && SYNC_REPLAYED_EVENT_TYPES.include?(event['type'])
+    snapshot = JSON.parse(event.to_s)
+    snapshot['created_at'] = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.%6NZ')
+    $sync_events << snapshot
+  end
+  $ws&.send(event.to_s)
+end
+
+# Whether a recorded event is at or after the client's `last_sync_at`.
+# Biases toward replay: when either timestamp is missing or unparseable, include the event,
+# because dropping a missed event is the failure /sync exists to prevent (the client dedupes).
+def event_after_sync?(created_at, last_sync_at)
+  return true unless created_at.kind_of?(String) && last_sync_at.kind_of?(String)
+
+  Time.parse(created_at) >= Time.parse(last_sync_at)
+rescue ArgumentError
+  true
 end
 
 def create_event(type:, channel_id:, parent_id: nil, user: current_user)

--- a/src/helpers/members.rb
+++ b/src/helpers/members.rb
@@ -24,7 +24,7 @@ def update_members(channel_id:, request_body:)
     ws_response['member'] = member
     ws_response['user'] = member['user']
     ws_response['created_at'] = unique_date
-    $ws&.send(ws_response.to_s)
+    broadcast_event(ws_response)
   end
 
   if remove_members
@@ -43,7 +43,7 @@ def update_members(channel_id:, request_body:)
   ws_response['type'] = 'channel.updated'
   ws_response['user'] = current_user
   ws_response['created_at'] = unique_date
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
 
   response = Mocks.update_member
   response['members'] = channel['members']

--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -73,7 +73,7 @@ def send_message_ws(response:, event_type:)
   ws_response['channel_id'] = response['message']['cid'].split(':').last
   ws_response['created_at'] = response['message']['created_at']
   ws_response['type'] = event_type
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
 end
 
 def find_message_by_id(id)
@@ -243,7 +243,7 @@ def create_draft(channel_id:, request_body:)
     channel['draft'] = draft_copy
   end
 
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
   response.to_s
 end
 
@@ -263,7 +263,7 @@ def delete_draft(channel_id:, params:)
   else
     channel['draft'] = nil
   end
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
   { duration: '7.11ms' }.to_s
 end
 
@@ -340,7 +340,7 @@ def mock_message(
     additional_response['channel_id'] = channel_id
     additional_response['type'] = 'message.updated'
     additional_response['message'] = parent_message
-    $ws&.send(additional_response.to_s)
+    broadcast_event(additional_response)
   end
 
   if !skip_enrich_url && (text.include?('youtube.com/') || text.include?('unsplash.com/') || text.include?('giphy.com/'))

--- a/src/helpers/reactions.rb
+++ b/src/helpers/reactions.rb
@@ -16,7 +16,7 @@ def send_reaction_ws(response:, event_type:)
   ws_response['channel_id'] = response['message']['cid'].split(':').last
   ws_response['created_at'] = response['reaction']['created_at']
   ws_response['type'] = event_type
-  $ws&.send(ws_response.to_s)
+  broadcast_event(ws_response)
 end
 
 def create_reaction(type:, message_id:, user: current_user, delete: nil, delay: nil)

--- a/src/robots/chat.rb
+++ b/src/robots/chat.rb
@@ -16,6 +16,7 @@ post '/mock' do
   reply_timestamp = 0
 
   $message_list = []
+  $sync_events = []
   $channel_list['channels'] = []
 
   channels_count.downto(1) do |i|

--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -100,10 +100,10 @@ post '/participant/message' do
   if params[:delay].to_i.positive?
     Thread.new do
       sleep(params[:delay].to_i)
-      $ws&.send(response.to_s)
+      broadcast_event(response)
     end
   else
-    $ws&.send(response.to_s)
+    broadcast_event(response)
   end
   sync_channels
 end

--- a/src/server.rb
+++ b/src/server.rb
@@ -2,6 +2,7 @@ require 'eventmachine'
 require 'faye/websocket'
 require 'puma'
 require 'json'
+require 'time'
 require 'sinatra'
 require 'securerandom'
 require_relative 'server/config'
@@ -21,6 +22,7 @@ require_relative 'robots/participant'
 
 $ws = nil
 $message_list = []
+$sync_events = []
 $channel_list = Mocks.channels
 $current_channel_id = Mocks.event_ws['channel_id']
 $health_check = Mocks.health_check.to_s

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -17,9 +17,17 @@ get '/ws/status' do
   { connected: !$ws.nil? }.to_json
 end
 
-# Synchronize
+# Synchronize: replay the events broadcast since `last_sync_at` for the requested channels,
+# so a client that missed live events while its socket was down recovers them on reconnect.
 post '/sync' do
-  { events: [] }.to_json
+  body = request.body.read
+  json = body.empty? ? {} : JSON.parse(body)
+  cids = json['channel_cids'] || []
+  last_sync_at = json['last_sync_at']
+  events = $sync_events.select do |event|
+    cids.include?(event['cid']) && event_after_sync?(event['created_at'], last_sync_at)
+  end
+  { events: events }.to_s
 end
 
 # Show channel list


### PR DESCRIPTION
### Goal

The mock broadcasts websocket events without recording them, and `POST /sync` returns `{"events": []}` unconditionally. An event that occurs while the client's socket is down is lost, and reconnect recovery cannot replay it. The real backend replays missed events through `/sync`.

The AND-1319 triage showed that the thread quote-delete e2e test stays non-deterministic when a delete event is lost during a socket drop. This change also protects any event-driven test from incidental mid-test socket drops on loaded CI emulators.

Resolves AND-1322

### Implementation

- New `broadcast_event(event)` helper sends the websocket event as before and records a deep-copy snapshot of it in `$sync_events`. All event send call sites now go through it; the health check stays as a raw send.
- Only the event types the real backend persists for `/sync` replay are recorded (channel lifecycle, notification added/removed from channel, message, reaction). Transient events (typing, read, member, draft) are broadcast live but never replayed, matching the backend.
- The snapshot is stamped with the broadcast time at sub-second precision. The client sorts sync events by `created_at` and rejects the batch when the newest event equals its `last_sync_at` watermark, so a replayed event must carry its occurrence time instead of a reused message timestamp.
- `POST /sync` returns the recorded events filtered by the request's `channel_cids` and `last_sync_at`.
- `$sync_events` resets on `POST /mock`, so every test starts clean.

Replayed events go through the same client pipeline as live events, so no client change is needed.

### Testing

Against a local server: the participant sent `typing.start`, a message, `typing.stop`, and a read event; `/sync` with the channel's cid and an earlier `last_sync_at` returned only the `message.new` event, with the full message payload. After a participant delete, `/sync` returned `message.new` and `message.deleted`, the delete stamped with its broadcast time. Wrong cid, future `last_sync_at`, and an empty request body all return no events. Rubocop clean.

Request field names and response shape were checked against both client SDKs: Android (`SyncHistoryRequest`, `SyncHistoryResponse`) and iOS (`MissingEventsRequestBody`, `MissingEventsPayload`).
