### PR TITLE
Reject a message send whose id already exists with a 400 like the real backend

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -80,6 +80,20 @@ def find_message_by_id(id)
   $message_list.detect { |msg| msg['id'] == id }
 end
 
+# Mirrors the backend response for a message sent with an id that already exists:
+# HTTP 400 with the input error code 4. Clients rely on the code and the
+# "already exists" text to recognize that the message was in fact delivered.
+def duplicate_message_error(message_id)
+  {
+    code: 4,
+    message: "a message with ID #{message_id} already exists",
+    StatusCode: 400,
+    duration: '0.10ms',
+    more_info: 'https://getstream.io/chat/docs/api_errors_response',
+    details: []
+  }.to_json
+end
+
 def update_message(request_body:, params:, delete: false)
   timestamp = unique_date
   json = request_body.empty? ? {} : JSON.parse(request_body)
@@ -125,6 +139,13 @@ def create_message(request_body:, channel_id: nil)
 
   json = JSON.parse(request_body)
   message = json['message']
+
+  # The real backend enforces message id uniqueness and rejects a duplicate send
+  # with a 400 input error (code 4). Mirror it so that a client retrying a message
+  # whose response was lost gets the same behavior as in production, and so that
+  # channel query responses can never contain the same message id twice.
+  halt(400, duplicate_message_error(message['id'])) if message['id'] && find_message_by_id(message['id'])
+
   parent_id = message['parent_id']
   quoted_message_id = message['quoted_message_id']
   channel_reply = message['show_in_channel']


### PR DESCRIPTION
### Goal

The real backend enforces message id uniqueness: sending a message whose id already exists returns a 400 input error (code 4, "a message with ID x already exists"). The mock server instead accepted the duplicate send and appended a second copy with the same id to the message list.

This happens in a real e2e sequence: the client sends a message, the connection drops before the response is processed, and the reconnect sync retries the send. With two copies stored, the channel query response contained the same message id twice, which crashed the Android Compose message list with a duplicate `LazyColumn` key (see the 2026-07-21 nightly, `test_userAddsReactionWhileOffline`).

Related: AND-1320

### Implementation

`create_message` now rejects a send whose message id is already tracked, before anything is stored or broadcast. The response mirrors the backend error body exactly: `code: 4`, `message: "a message with ID <id> already exists"`, `StatusCode: 400`. The originally stored message stays untouched.

The Android SDK side, which marks the retried message as delivered instead of permanently failed when it receives this rejection, is in https://github.com/GetStream/stream-chat-android/pull/6587. The iOS SDK already handles this rejection.

### Testing

- `bundle exec rubocop`: no offenses.
- Manual: start the driver, create a test instance, and POST the same message body twice to `/channels/messaging/<id>/message`. The first returns 200, the second returns 400 with the backend-shaped body, and the message stays stored once.
- Ran the Android `test_userAddsReactionWhileOffline` e2e test locally against this branch: green.
