### PR TITLE
Apply unpin partial updates and stamp participant message events with the current created_at

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -108,7 +108,7 @@ def update_message(request_body:, params:, delete: false)
     message['text'] = json['set']['text']
     message['html'] = json['set']['text'].to_html
     message['message_text_updated_at'] = timestamp
-  elsif json['set'] && json['set']['pinned']
+  elsif json['set'] && json['set'].key?('pinned')
     message['pinned'] = json['set']['pinned']
     message['pinned_by'] = json['set']['pinned'] ? current_user : nil
     message['pinned_at'] = json['set']['pinned'] ? timestamp : nil

--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -93,6 +93,7 @@ post '/participant/message' do
   response['channel_id'] = message['channel_id']
   response['cid'] = "messaging:#{message['channel_id']}"
   response['type'] = action_type
+  response['created_at'] = timestamp
   response['message'] = message
   response['user'] = Participant.user
   response['hard_delete'] = true if params[:hard_delete] == 'true' && params[:action] == 'delete'


### PR DESCRIPTION
### Goal

Two fixes needed by the upcoming Android pinned-message e2e tests (the first pin coverage on any platform).

1. Unpin was silently dropped. The Android SDK unpins a message with a partial update `set: {pinned: false}`. The update handler branched on the value of `set.pinned`, which is falsy for `false`, so the unpin never applied and no `message.updated` event was sent.
2. Participant message events carried a stale template timestamp. The `/participant/message` route never set the event-level `created_at`, so every event it broadcast kept the static date from the `ws_events.json` template. The Android client sorts each batch of near-simultaneous events by event `created_at`, so a participant pin (dated with the template's old date) was applied before the `message.new` echo of the message it pinned, and the pin was overwritten.

Related: AND-1328

### Implementation

- `update_message` branches on the presence of the `pinned` key instead of its value, so `pinned: false` is applied like `pinned: true`.
- The `/participant/message` route stamps the event's `created_at` with the current timestamp, the same way `create_event` and `create_reaction` already do. This affects all participant message events, not only pins, which matches the real backend: an event is dated when it happens.

### Testing

- `bundle exec rubocop`: no offenses.
- Ran the new Android `PinnedMessagesTests` (4 tests: user pin, user unpin, participant pin, participant unpin) locally against this branch: all green. Against main, only user pin passes.
- Regression: ran the Android `ChannelListTests` (12 tests) and `ReactionsTests` (10 tests) locally against this branch: all green. These cover the participant message and reaction flows affected by the timestamp change.
- iOS is unaffected today: its e2e suite has no pin tests, and the timestamp fix only corrects the event date.