### PR TITLE
Add truncate channel route for v2 endpoints

### DIFF
--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -118,6 +118,11 @@ post '/channels/messaging/:channel_id/truncate' do
   truncate_channel(channel_id: params[:channel_id], request_body: request.body.read)
 end
 
+# Truncate channel (v2)
+post '/api/v2/chat/channels/messaging/:channel_id/truncate' do
+  truncate_channel(channel_id: params[:channel_id], request_body: request.body.read)
+end
+
 # Add/remove channel member
 post '/channels/messaging/:channel_id' do
   update_members(channel_id: params[:channel_id], request_body: request.body.read)


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1843](https://linear.app/stream/issue/IOS-1843)

https://github.com/GetStream/stream-chat-swift/pull/4205 requires v2 route for truncate channel endpoint. Responses are compatible.

### 🧪 Testing Notes

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch) - [verification job](https://github.com/GetStream/stream-chat-swift/actions/runs/31103525073)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch) - [verification job](https://github.com/GetStream/stream-chat-android/actions/runs/31103594719)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch) - [verification job](https://github.com/GetStream/stream-chat-flutter/actions/runs/31103606282)
