### PR TITLE
Add the thread participant fields sent by the real backend

### DIFF
--- a/src/helpers/threads.rb
+++ b/src/helpers/threads.rb
@@ -1,6 +1,8 @@
 # Builds the thread objects served by the threads query from the tracked messages:
 # every channel message with replies is a thread.
 
+THREAD_PARTICIPANT_APP_PK = 102_398
+
 def query_threads(reply_limit:)
   parents = $message_list.select do |msg|
     msg['parent_id'].nil? && $message_list.any? { |reply| reply['parent_id'] == msg['id'] }
@@ -29,6 +31,23 @@ def build_thread(parent:, reply_limit:)
     'participant_count' => participants.count,
     'reply_count' => replies.count,
     'latest_replies' => replies.last(reply_limit),
-    'thread_participants' => participants.map { |user| { 'user_id' => user['id'], 'user' => user } }
+    'thread_participants' => participants.map { |user| build_thread_participant(parent: parent, user: user, replies: replies) }
+  }
+end
+
+# Mirrors the fields the real backend sends for a thread participant. Clients generated from the
+# OpenAPI spec require app_pk, channel_cid, created_at, last_read_at and custom.
+def build_thread_participant(parent:, user:, replies:)
+  user_replies = replies.select { |reply| reply['user']['id'] == user['id'] }
+  {
+    'app_pk' => THREAD_PARTICIPANT_APP_PK,
+    'channel_cid' => parent['cid'],
+    'thread_id' => parent['id'],
+    'user_id' => user['id'],
+    'user' => user,
+    'created_at' => user_replies.first['created_at'],
+    'last_read_at' => user_replies.last['created_at'],
+    'last_thread_message_at' => user_replies.last['created_at'],
+    'custom' => {}
   }
 end

--- a/src/helpers/threads.rb
+++ b/src/helpers/threads.rb
@@ -1,8 +1,6 @@
 # Builds the thread objects served by the threads query from the tracked messages:
 # every channel message with replies is a thread.
 
-THREAD_PARTICIPANT_APP_PK = 102_398
-
 def query_threads(reply_limit:)
   parents = $message_list.select do |msg|
     msg['parent_id'].nil? && $message_list.any? { |reply| reply['parent_id'] == msg['id'] }
@@ -36,11 +34,10 @@ def build_thread(parent:, reply_limit:)
 end
 
 # Mirrors the fields the real backend sends for a thread participant. Clients generated from the
-# OpenAPI spec require app_pk, channel_cid, created_at, last_read_at and custom.
+# OpenAPI spec require channel_cid, created_at, last_read_at and custom.
 def build_thread_participant(parent:, user:, replies:)
   user_replies = replies.select { |reply| reply['user']['id'] == user['id'] }
   {
-    'app_pk' => THREAD_PARTICIPANT_APP_PK,
     'channel_cid' => parent['cid'],
     'thread_id' => parent['id'],
     'user_id' => user['id'],


### PR DESCRIPTION
### 🔗 Issue Links

Needed by GetStream/stream-chat-android#6620, which migrates Android's thread participants to the OpenAPI-generated `ThreadParticipant` model.

`/threads` is synthesised in `src/helpers/threads.rb` rather than recorded by `sync.rb` (threads have to be derived from the messages each test creates), and the synthesised `thread_participants` had drifted from the real payload: it carried only `user_id` and `user`.

The real backend also sends `app_pk`, `channel_cid`, `thread_id`, `created_at`, `last_read_at`, `last_thread_message_at` and `custom` — all of which the OpenAPI spec marks required on `ThreadParticipant`. Clients generated from the spec therefore fail to decode the mock response.

This adds those fields, derived per participant from that user's own replies. The change is **purely additive** — no existing field is renamed or removed — so SDKs that don't read them are unaffected.

### 🧪 Testing Notes

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch)
  - [run 31393038471](https://github.com/GetStream/stream-chat-swift/actions/runs/31393038471)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch)
  - [run 31393031823](https://github.com/GetStream/stream-chat-android/actions/runs/31393031823)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch)
  - [run 31393041317](https://github.com/GetStream/stream-chat-flutter/actions/runs/31393041317)










