### PR TITLE
Add query reactions route for v2 endpoints

### DIFF
--- a/src/helpers/reactions.rb
+++ b/src/helpers/reactions.rb
@@ -21,6 +21,18 @@ def send_reaction_ws(response:, event_type:)
   broadcast_event(ws_response)
 end
 
+def query_reactions(message_id:, request_body:)
+  json = request_body.empty? ? {} : JSON.parse(request_body)
+  filter_type = json.dig('filter', 'type')
+  filter_type = filter_type.values.first if filter_type.kind_of?(Hash)
+  message = find_message_by_id(message_id)
+  halt(400, { message: "message #{message_id} not found" }.to_s) unless message
+
+  reactions = message['latest_reactions'] || []
+  reactions = reactions.select { |reaction| reaction['type'] == filter_type } if filter_type
+  { reactions: reactions, duration: '7.11ms' }.to_s
+end
+
 def create_reaction(type:, message_id:, user: current_user, delete: nil, delay: nil)
   timestamp = unique_date
   message = find_message_by_id(message_id)

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -238,16 +238,12 @@ end
 
 # Query message reactions
 post '/messages/:message_id/reactions' do
-  body = request.body.read
-  json = body.empty? ? {} : JSON.parse(body)
-  filter_type = json.dig('filter', 'type')
-  filter_type = filter_type.values.first if filter_type.kind_of?(Hash)
-  message = find_message_by_id(params[:message_id])
-  halt(400, { message: "message #{params[:message_id]} not found" }.to_s) unless message
+  query_reactions(message_id: params[:message_id], request_body: request.body.read)
+end
 
-  reactions = message['latest_reactions'] || []
-  reactions = reactions.select { |reaction| reaction['type'] == filter_type } if filter_type
-  { reactions: reactions, duration: '7.11ms' }.to_s
+# Query message reactions (v2)
+post '/api/v2/chat/messages/:message_id/reactions' do
+  query_reactions(message_id: params[:message_id], request_body: request.body.read)
 end
 
 # Flag message or user


### PR DESCRIPTION
### 🔗 Issue Links

Related: [IOS-1957](https://linear.app/stream/issue/IOS-1957/openapi-migrate-reaction-read-endpoints)

The iOS SDK is migrating its reaction read endpoints to the OpenAPI v2 paths, so `queryReactions` now requests `/api/v2/chat/messages/{id}/reactions` instead of the prefix-less v1 path. This adds the v2 companion route, mirroring what was done for truncate channel in #55.

The handler body is unchanged and now shared between both routes via a new `query_reactions` helper — the v2 request body has the same `filter`/`limit` shape, so no parsing changes were needed. The v1 route stays in place for the SDKs that have not migrated yet.

Only the query (POST) route is added: send and delete reactions remain on v1 in the iOS SDK, and there is no v1 GET-reactions route today.

### 🧪 Testing Notes

Verified locally by booting the server and confirming both routes return identical responses, with an unknown path returning 404 as a control:

```
POST /api/v2/chat/messages/does-not-exist/reactions → 400 {"message": "message does-not-exist not found"}
POST /messages/does-not-exist/reactions             → 400 {"message": "message does-not-exist not found"}
POST /api/v2/chat/messages/x/nope                   → 404
```

Note that no current iOS E2E test opens the reaction authors list, so `Reactions_Tests` does not exercise this route yet — it is added so the migrated SDK path is covered when it does.

Please verify the E2E test runs:
- [ ] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch) [Job](https://github.com/GetStream/stream-chat-swift/actions/runs/31491722854)
- [ ] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch) [Job](https://github.com/GetStream/stream-chat-android/actions/runs/31491732944)
- [ ] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch) [Job
](https://github.com/GetStream/stream-chat-flutter/actions/runs/31491738815)