### PR TITLE
Add the duration field to the file upload responses

### DIFF
--- a/src/server/data.rb
+++ b/src/server/data.rb
@@ -34,3 +34,10 @@ def test_asset(type)
   }
   assets[type]
 end
+
+# The real backend answers uploads with the asset URL, the request duration and,
+# only when a thumbnail was generated, a `thumb_url`. Clients parse `duration` as
+# non-null, so it has to be there on every upload response.
+def upload_response(type)
+  { file: test_asset(type), duration: '49.41ms' }
+end

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -139,26 +139,22 @@ end
 
 # Send image
 post '/channels/messaging/:channel_id/image' do
-  file = test_asset('image')
-  { file: file }.to_s
+  upload_response('image').to_json
 end
 
 # Send file
 post '/channels/messaging/:channel_id/file' do
-  file = request.content_type.include?('video') ? test_asset('video') : test_asset('file')
-  { file: file }.to_s
+  upload_response(request.content_type.include?('video') ? 'video' : 'file').to_json
 end
 
 # Send image (v2)
 post '/api/v2/chat/channels/messaging/:channel_id/image' do
-  file = test_asset('image')
-  { file: file }.to_s
+  upload_response('image').to_json
 end
 
 # Send file (v2)
 post '/api/v2/chat/channels/messaging/:channel_id/file' do
-  file = request.content_type.include?('video') ? test_asset('video') : test_asset('file')
-  { file: file }.to_s
+  upload_response(request.content_type.include?('video') ? 'video' : 'file').to_json
 end
 
 # Send reaction


### PR DESCRIPTION
### 🔗 Issue Links

Surfaced by GetStream/stream-chat-android#6632, which switches Android's uploads to the OpenAPI-generated model.

- The four file/image upload routes returned only `file`. In the backend OpenAPI specs, `duration` is the only **required** property of `FileUploadResponse`/`ImageUploadResponse` — `file` and `thumb_url` are optional — so every client generated from them has `duration` mandatory and fails to decode the mock response (on Android: `Required value 'duration' missing at $`).
- Added a shared `upload_response` helper and used it in all four routes. `thumb_url` stays omitted, as the real backend omits it when no thumbnail was generated.
- Those routes built their body with `.to_s` (Ruby hash-inspect, not JSON) and now use `.to_json`. The ~16 other `.to_s` bodies in `endpoints.rb` are a follow-up.
- Verified by `POST`ing all four routes against a local server: valid JSON with `file` and `duration`.

### 🧪 Testing Notes

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch)
  - [run 31574861012](https://github.com/GetStream/stream-chat-swift/actions/runs/31574861012)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch)
  - [run 31574863162](https://github.com/GetStream/stream-chat-android/actions/runs/31574863162) — green on all 7 API levels, `AttachmentsTests` included
- [ ] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch)
  - [run 31574865177](https://github.com/GetStream/stream-chat-flutter/actions/runs/31574865177) — fails, but not because of this branch: last night's [nightly on mock `main`](https://github.com/GetStream/stream-chat-flutter/actions/runs/31553804071) fails identically (`message_list_test`/`reactions_test`, same counts, same `RawTooltipState is a SingleTickerProviderStateMixin but multiple tickers were created` assertion). No attachment test involved and no upload decode error in the logs.
