### PR TITLE
Fix the member add branch selection and send the user objects on blocked users

### DIFF
--- a/src/helpers/members.rb
+++ b/src/helpers/members.rb
@@ -1,8 +1,8 @@
 def update_members(channel_id:, request_body:)
   channel = find_channel_by_id(channel_id)
   json = request_body.empty? ? {} : JSON.parse(request_body)
-  remove_members = json['remove_members'] ? true : false
-  member_ids = remove_members ? json['remove_members'] : json['add_members']
+  remove_members = json['remove_members']&.any? || false
+  member_ids = (remove_members ? json['remove_members'] : json['add_members']) || []
 
   unless remove_members
     member = Mocks.member

--- a/src/helpers/moderation.rb
+++ b/src/helpers/moderation.rb
@@ -91,7 +91,9 @@ def block_user(blocked_user_id:)
   block = {
     'user_id' => current_user['id'],
     'blocked_user_id' => blocked_user_id,
-    'created_at' => timestamp
+    'created_at' => timestamp,
+    'user' => current_user,
+    'blocked_user' => current_user.merge('id' => blocked_user_id)
   }
   $blocked_users << block
   {


### PR DESCRIPTION
### 🔗 Issue Links

_No tracking issue._

Two fixes, both surfaced by clients generated from the OpenAPI models.

#### `update_members` picks the wrong branch when `remove_members` is empty

The helper picked the add/remove branch by whether `remove_members` was *present*, but an empty array is
truthy in Ruby:

```ruby
remove_members = json['remove_members'] ? true : false
```

- Generated clients send every action list on every call, so an `add_members` request arrives carrying
  `"remove_members":[]`. The helper then took the remove branch, ignored `add_members`, and broadcast no
  `member.added` event.
- The fix picks the branch by whether the list has entries, and defaults `member_ids` to an empty list so a
  body that omits both keys no longer raises `NoMethodError` on `nil.each`.
- Behaviour per payload shape, old vs new:

  | body | before | after |
  | --- | --- | --- |
  | `add_members:["jc"], remove_members:[]` | `REMOVE, []` | `ADD, ["jc"]` |
  | `add_members:[], remove_members:["jc"]` | `REMOVE, ["jc"]` | unchanged |
  | `add_members:[], remove_members:[]` | `REMOVE, []` | `ADD, []` (no-op either way) |
  | `add_members:["jc"]` (no remove key) | `ADD, ["jc"]` | unchanged |
  | `remove_members:["jc"]` (no add key) | `REMOVE, ["jc"]` | unchanged |
  | `{}` | `ADD, nil` then raises | `ADD, []` |

  Only the first and last rows change, so bodies from the current clients keep their existing behaviour.

#### `GET /users/block` omits the user objects the response declares

Each stored block carried only `user_id`, `blocked_user_id` and `created_at`. The generated
`BlockedUserResponse` declares `user` and `blocked_user` as required non-null user objects, so a client
using it fails to parse the list with `Required value 'blockedUser' (JSON name 'blocked_user') missing`.

- `block_user` now stores both: `user` is the current user, and `blocked_user` is that same object with the
  id replaced, which is enough to satisfy every field the response requires (`banned`, `created_at`, `id`,
  `language`, `online`, `role`, `updated_at`).
- Nothing is red today, because no E2E test blocks a user, so this is what makes such a test possible
  rather than a fix for a current failure.

### 🧪 Testing Notes

- Verified the member branch selection for each payload shape in the table above, against both the old and
  the new expression.
- Verified the blocked-users payload now carries every field the generated response requires, including the
  nested user objects.

Please verify the E2E test runs. The earlier runs were against the member fix alone, so they no longer
cover this branch and need repeating:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch)
  - [run 32346262624](https://github.com/GetStream/stream-chat-swift/actions/runs/32346262624)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch)
  - [run 32346264904](https://github.com/GetStream/stream-chat-android/actions/runs/32346264904)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch)
  - [run 32346266622](https://github.com/GetStream/stream-chat-flutter/actions/runs/32346266622)

