### PR TITLE
Add message request and reaction routes for v2 endpoints

### DIFF
--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -212,6 +212,11 @@ post '/channels/messaging/:channel_id' do
   update_members(channel_id: params[:channel_id], request_body: request.body.read)
 end
 
+# Add/remove channel member (v2)
+post '/api/v2/chat/channels/messaging/:channel_id' do
+  update_members(channel_id: params[:channel_id], request_body: request.body.read)
+end
+
 # Delete channel
 delete '/channels/messaging/:channel_id' do
   channel = find_channel_by_id(params[:channel_id])

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -101,6 +101,11 @@ post '/channels/messaging/:channel_id/message' do
   create_message(request_body: request.body.read, channel_id: params[:channel_id])
 end
 
+# Send message (v2)
+post '/api/v2/chat/channels/messaging/:channel_id/message' do
+  create_message(request_body: request.body.read, channel_id: params[:channel_id])
+end
+
 # Get message
 get '/messages/:message_id' do
   message = find_message_by_id(params[:message_id])
@@ -109,6 +114,11 @@ end
 
 # Update message
 post '/messages/:message_id' do
+  update_message(request_body: request.body.read, params: params)
+end
+
+# Update message (v2)
+post '/api/v2/chat/messages/:message_id' do
   update_message(request_body: request.body.read, params: params)
 end
 
@@ -122,8 +132,18 @@ put '/messages/:message_id' do
   update_message(request_body: request.body.read, params: params)
 end
 
+# Edit or pin message (v2)
+put '/api/v2/chat/messages/:message_id' do
+  update_message(request_body: request.body.read, params: params)
+end
+
 # Create draft message
 post '/channels/messaging/:channel_id/draft' do
+  create_draft(channel_id: params[:channel_id], request_body: request.body.read)
+end
+
+# Create draft message (v2)
+post '/api/v2/chat/channels/messaging/:channel_id/draft' do
   create_draft(channel_id: params[:channel_id], request_body: request.body.read)
 end
 
@@ -162,8 +182,18 @@ post '/messages/:message_id/reaction' do
   create_reaction(type: JSON.parse(request.body.read)['reaction']['type'], message_id: params[:message_id])
 end
 
+# Send reaction (v2)
+post '/api/v2/chat/messages/:message_id/reaction' do
+  create_reaction(type: JSON.parse(request.body.read)['reaction']['type'], message_id: params[:message_id])
+end
+
 # Delete reaction
 delete '/messages/:message_id/reaction/:reaction_type' do
+  create_reaction(type: params[:reaction_type], message_id: params[:message_id], delete: true)
+end
+
+# Delete reaction (v2)
+delete '/api/v2/chat/messages/:message_id/reaction/:reaction_type' do
   create_reaction(type: params[:reaction_type], message_id: params[:message_id], delete: true)
 end
 


### PR DESCRIPTION
Adds `/api/v2/chat` companion routes for the chat endpoints that the iOS SDK has migrated to the generated v2 client, so the E2E suite keeps hitting the mock server once those calls change path.

Each new route delegates to the same helper as its v1 counterpart and sits directly after it, matching the existing v2 upload and truncate companions. No helper changes were needed: `create_message`, `update_message`, `create_draft`, `create_reaction`, and `update_members` only read standard fields (`id`, `text`, `parent_id`, `show_in_channel`, `set.text`, `set.pinned`, `reaction.type`, `add_members`, `remove_members`), which occupy the same position in the v2 request bodies.

| Route | Endpoint |
| --- | --- |
| `POST /api/v2/chat/channels/messaging/:channel_id/message` | send message |
| `POST /api/v2/chat/messages/:message_id` | update message |
| `PUT /api/v2/chat/messages/:message_id` | partial update (edit / pin) |
| `POST /api/v2/chat/channels/messaging/:channel_id/draft` | create draft |
| `POST /api/v2/chat/messages/:message_id/reaction` | send reaction |
| `DELETE /api/v2/chat/messages/:message_id/reaction/:reaction_type` | delete reaction |
| `POST /api/v2/chat/channels/messaging/:channel_id` | update channel (add / remove members) |

The v1 routes are left untouched, so clients that have not migrated are unaffected.

### 🔗 Issue Links

Related: [IOS-1620](https://linear.app/stream/issue/IOS-1620/openapi-generation-in-llc)

### 🧪 Testing Notes

Verified locally against a running mock server — each new message route returns `200` and the expected payload:

- send: response `message` carries every field the generated `MessagePayload` requires, including the non-optional `html`
- update: `text` and `html` both updated
- partial update: `pinned: true` with `pinned_by` set
- create draft: response envelope is `{draft, duration}`, matching the generated `CreateDraftResponse`
- update channel: `add_members` (with and without a nested `custom`), `remove_members`, and an attached system `message` all return `200`, and the emitted `member.added` / `member.removed` / `channel.updated` events are unchanged from the v1 route

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch) - [Verification](https://github.com/GetStream/stream-chat-swift/actions/runs/32170363941)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch) - [Verification](https://github.com/GetStream/stream-chat-android/actions/runs/32170374552)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch) - [Verification](https://github.com/GetStream/stream-chat-flutter/actions/runs/32170385274)

