### PR TITLE
Do not broadcast message.new for ephemeral messages

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -64,6 +64,15 @@ class AttachmentActionType
   end
 end
 
+# The real backend broadcasts message.new only for regular, reply and system
+# messages. An ephemeral message (the giphy preview) is visible to its sender
+# only and gets no event: it reaches the sender in the send response instead.
+# Broadcasting one lets the event arrive after the sender cancelled the preview
+# and bring the cancelled message back.
+def broadcast_new_message?(message_type)
+  [MessageType.regular, MessageType.reply, MessageType.system].include?(message_type)
+end
+
 def send_message_ws(response:, event_type:)
   ws_response = Mocks.message_ws
   ws_response['message_id'] = response['message']['id']
@@ -209,7 +218,7 @@ def create_message(request_body:, channel_id: nil)
 
   response['message'] = mocked_message
   track_message_read_states(channel_id: channel_id, message: mocked_message) if message_type == :regular
-  send_message_ws(response: response, event_type: MessageEventType.new) if message_type != :error
+  send_message_ws(response: response, event_type: MessageEventType.new) if broadcast_new_message?(message_type)
   response.to_s
 end
 


### PR DESCRIPTION
### 🔗 Issue Links

[AND-1404](https://linear.app/stream/issue/AND-1404/fix-the-e2e-flake-where-a-cancelled-giphy-preview-comes-back)

### 📝 Summary

The mock sent a `message.new` websocket event for every message that was not an error, so an ephemeral message (the giphy preview) got one as well. The real backend sends `message.new` only for regular, reply and system messages. An ephemeral message is visible to its sender only and reaches that sender in the send response, so there is no event for it.

That extra event can bring a cancelled preview back. Cancel deletes the ephemeral message locally with no server call, so a `message.new` that is processed after the delete inserts the message again. The Android client batches socket events for up to 1 second, which is enough for the event to arrive after the cancel. This is what failed `test_messageIsNotSent_whenUserCancelsEphemeralMessage` on API 35 in the nightly of 2026-08-18.

Two nearby paths keep their event on purpose:
- the giphy Send action, because the message becomes regular at that point
- participant messages, which are broadcast from `/participant/message` and are never ephemeral

### 🧪 Testing Notes

Verified locally on an API 35 emulator against this branch:

- with a 1.2 second delay added to the ephemeral event, `test_messageIsNotSent_whenUserCancelsEphemeralMessage` fails the same way as in CI: the cancelled preview reappears in the message list
- with this change all 10 `GiphyTests` pass, and the client receives no `message.new` at all for the ephemeral message
- `test_channelPreviewUpdates_whenUserSendsMessage`, `test_channelPreviewIsUpdated_whenThreadReplyIsSentAlsoInTheChannel` and `test_channelPreviewUpdates_whenParticipantSendsMessage` pass, so the regular and reply events still work

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/runs/32128739843)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/runs/32128736086)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/runs/32128743784)


