### PR TITLE
Add the poll endpoints, poll state on messages and the poll websocket events

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -216,6 +216,12 @@ def create_message(request_body:, channel_id: nil)
     track_message: message_type != :error
   )
 
+  # The poll message arrives with the poll id flattened onto the message root
+  # (`poll_id`), never as a nested poll object: the client creates the poll with
+  # POST /polls first and then sends a regular message referencing it.
+  poll = message['poll_id'] ? find_poll(message['poll_id']) : nil
+  mocked_message['poll'] = poll if poll
+
   response['message'] = mocked_message
   track_message_read_states(channel_id: channel_id, message: mocked_message) if message_type == :regular
   send_message_ws(response: response, event_type: MessageEventType.new) if broadcast_new_message?(message_type)

--- a/src/helpers/polls.rb
+++ b/src/helpers/polls.rb
@@ -105,6 +105,15 @@ def update_poll(request_body:)
   { poll: poll, duration: '7.11ms' }.to_s
 end
 
+# The keys every client parses as required on a poll payload. Like the real backend,
+# `unset` only removes keys outside this set (custom data): nil-ing or dropping a core
+# key would poison the poll embedded on its message and break every later channel query.
+POLL_CORE_KEYS = %w[
+  id name description options allow_answers allow_user_suggested_options enforce_unique_vote
+  voting_visibility is_closed created_by created_by_id created_at updated_at vote_count
+  answers_count own_votes latest_answers latest_votes_by_option vote_counts_by_option
+].freeze
+
 def partial_update_poll(poll_id:, request_body:)
   json = JSON.parse(request_body)
   poll = find_poll(poll_id)
@@ -112,7 +121,7 @@ def partial_update_poll(poll_id:, request_body:)
 
   closing = json.dig('set', 'is_closed') && !poll['is_closed']
   (json['set'] || {}).each { |key, value| poll[key] = value }
-  (json['unset'] || []).each { |key| poll[key] = nil }
+  (json['unset'] || []).each { |key| poll.delete(key) unless POLL_CORE_KEYS.include?(key) }
   poll['updated_at'] = unique_date
   broadcast_poll_event(type: closing ? PollEventType.closed : PollEventType.updated, poll: poll)
   { poll: poll, duration: '7.11ms' }.to_s
@@ -151,6 +160,16 @@ def update_poll_option(poll_id:, request_body:)
   option['text'] = json['text'].to_s
   poll['updated_at'] = unique_date
   broadcast_poll_event(type: PollEventType.updated, poll: poll)
+  { poll_option: option, duration: '7.11ms' }.to_s
+end
+
+def get_poll_option(poll_id:, option_id:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  option = poll['options'].detect { |opt| opt['id'] == option_id }
+  halt(400, { message: "option #{option_id} not found" }.to_s) unless option
+
   { poll_option: option, duration: '7.11ms' }.to_s
 end
 

--- a/src/helpers/polls.rb
+++ b/src/helpers/polls.rb
@@ -1,0 +1,291 @@
+# Polls live in $polls and are embedded on their message under `poll` by reference,
+# so an in-place poll mutation is visible in every later message list response
+# without re-linking. `own_votes` holds only the app user's votes: the poll payload
+# is always serialized from the app user's point of view, and participant votes
+# reach the app user through the vote events instead.
+
+class PollEventType
+  def self.updated
+    'poll.updated'
+  end
+
+  def self.closed
+    'poll.closed'
+  end
+
+  def self.deleted
+    'poll.deleted'
+  end
+
+  def self.vote_casted
+    'poll.vote_casted'
+  end
+
+  def self.vote_changed
+    'poll.vote_changed'
+  end
+
+  def self.vote_removed
+    'poll.vote_removed'
+  end
+end
+
+def find_poll(poll_id)
+  $polls.detect { |poll| poll['id'] == poll_id }
+end
+
+def find_poll_message(poll_id)
+  $message_list.detect { |msg| msg.dig('poll', 'id') == poll_id }
+end
+
+def poll_option(text)
+  { 'id' => unique_id, 'text' => text.to_s }
+end
+
+# Answer votes carry `is_answer` and `answer_text` on top of this shape, with an
+# empty `option_id`: clients parse `option_id` as a required non-null string.
+def poll_vote(poll_id:, option_id:, user:, timestamp:)
+  {
+    'id' => unique_id,
+    'poll_id' => poll_id,
+    'option_id' => option_id,
+    'user' => user,
+    'user_id' => user['id'],
+    'created_at' => timestamp,
+    'updated_at' => timestamp
+  }
+end
+
+def create_poll(request_body:)
+  json = JSON.parse(request_body)
+  timestamp = unique_date
+  poll = {
+    'id' => json['id'] || unique_id,
+    'name' => json['name'].to_s,
+    'description' => json['description'].to_s,
+    'options' => (json['options'] || []).map { |option| poll_option(option['text']) },
+    'allow_answers' => json['allow_answers'] || false,
+    'allow_user_suggested_options' => json['allow_user_suggested_options'] || false,
+    'enforce_unique_vote' => json['enforce_unique_vote'] || false,
+    'max_votes_allowed' => json['max_votes_allowed'],
+    'voting_visibility' => json['voting_visibility'] || 'public',
+    'is_closed' => json['is_closed'] || false,
+    'created_by' => current_user,
+    'created_by_id' => current_user['id'],
+    'created_at' => timestamp,
+    'updated_at' => timestamp,
+    'vote_count' => 0,
+    'answers_count' => 0,
+    'own_votes' => [],
+    'latest_answers' => [],
+    'latest_votes_by_option' => {},
+    'vote_counts_by_option' => {}
+  }
+  $polls << poll
+  { poll: poll, duration: '7.11ms' }.to_s
+end
+
+def update_poll(request_body:)
+  json = JSON.parse(request_body)
+  poll = find_poll(json['id'])
+  halt(400, { message: "poll #{json['id']} not found" }.to_s) unless poll
+
+  %w[name description allow_answers allow_user_suggested_options enforce_unique_vote
+     max_votes_allowed voting_visibility is_closed].each do |key|
+    poll[key] = json[key] if json.key?(key)
+  end
+  if json['options']
+    poll['options'] = json['options'].map do |option|
+      existing = poll['options'].detect { |opt| opt['id'] == option['id'] }
+      existing ? existing.merge('text' => option['text'].to_s) : poll_option(option['text'])
+    end
+  end
+  poll['updated_at'] = unique_date
+  broadcast_poll_event(type: PollEventType.updated, poll: poll)
+  { poll: poll, duration: '7.11ms' }.to_s
+end
+
+def partial_update_poll(poll_id:, request_body:)
+  json = JSON.parse(request_body)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  closing = json.dig('set', 'is_closed') && !poll['is_closed']
+  (json['set'] || {}).each { |key, value| poll[key] = value }
+  (json['unset'] || []).each { |key| poll[key] = nil }
+  poll['updated_at'] = unique_date
+  broadcast_poll_event(type: closing ? PollEventType.closed : PollEventType.updated, poll: poll)
+  { poll: poll, duration: '7.11ms' }.to_s
+end
+
+def delete_poll(poll_id:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  message = find_poll_message(poll_id)
+  $polls.delete(poll)
+  message['poll'] = nil if message
+  broadcast_poll_event(type: PollEventType.deleted, poll: poll, message: message)
+  { duration: '7.11ms' }.to_s
+end
+
+def create_poll_option(poll_id:, request_body:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  option = poll_option(JSON.parse(request_body)['text'])
+  poll['options'] << option
+  poll['updated_at'] = unique_date
+  broadcast_poll_event(type: PollEventType.updated, poll: poll)
+  { poll_option: option, duration: '7.11ms' }.to_s
+end
+
+def update_poll_option(poll_id:, request_body:)
+  json = JSON.parse(request_body)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  option = poll['options'].detect { |opt| opt['id'] == json['id'] }
+  halt(400, { message: "option #{json['id']} not found" }.to_s) unless option
+
+  option['text'] = json['text'].to_s
+  poll['updated_at'] = unique_date
+  broadcast_poll_event(type: PollEventType.updated, poll: poll)
+  { poll_option: option, duration: '7.11ms' }.to_s
+end
+
+def delete_poll_option(poll_id:, option_id:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  poll['options'].delete_if { |option| option['id'] == option_id }
+  removed_votes = poll['latest_votes_by_option'].delete(option_id) || []
+  poll['vote_counts_by_option'].delete(option_id)
+  poll['vote_count'] -= removed_votes.count
+  poll['own_votes'].delete_if { |vote| vote['option_id'] == option_id }
+  poll['updated_at'] = unique_date
+  broadcast_poll_event(type: PollEventType.updated, poll: poll)
+  { duration: '7.11ms' }.to_s
+end
+
+def query_poll_votes(poll_id:, request_body:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  json = request_body.empty? ? {} : JSON.parse(request_body)
+  filter = json['filter'] || {}
+  votes =
+    if filter['is_answer']
+      poll['latest_answers']
+    elsif filter['option_id']
+      poll['latest_votes_by_option'][filter['option_id']] || []
+    else
+      poll['latest_votes_by_option'].values.flatten + poll['latest_answers']
+    end
+  votes = votes.first(json['limit'].to_i) if json['limit']
+  { votes: votes, duration: '7.11ms' }.to_s
+end
+
+def cast_poll_vote(message_id:, poll_id:, vote_data:, user: current_user)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  timestamp = unique_date
+  if vote_data['answer_text']
+    vote = poll_vote(poll_id: poll_id, option_id: '', user: user, timestamp: timestamp)
+    vote['is_answer'] = true
+    vote['answer_text'] = vote_data['answer_text']
+    poll['latest_answers'].unshift(vote)
+    poll['answers_count'] += 1
+    event_type = PollEventType.vote_casted
+  else
+    option_id = vote_data['option_id']
+    halt(400, { message: "option #{option_id} not found" }.to_s) unless poll['options'].any? { |opt| opt['id'] == option_id }
+
+    previous_votes = poll['enforce_unique_vote'] ? remove_user_votes(poll: poll, user: user) : []
+    vote = poll_vote(poll_id: poll_id, option_id: option_id, user: user, timestamp: timestamp)
+    (poll['latest_votes_by_option'][option_id] ||= []) << vote
+    poll['vote_counts_by_option'][option_id] = (poll['vote_counts_by_option'][option_id] || 0) + 1
+    poll['vote_count'] += 1
+    poll['own_votes'] << vote if user['id'] == current_user['id']
+    event_type = previous_votes.any? ? PollEventType.vote_changed : PollEventType.vote_casted
+  end
+
+  poll['updated_at'] = timestamp
+  broadcast_poll_event(
+    type: event_type,
+    poll: poll,
+    poll_vote: vote,
+    message: find_message_by_id(message_id)
+  )
+  { vote: vote, duration: '7.11ms' }.to_s
+end
+
+def remove_poll_vote(message_id:, poll_id:, vote_id:)
+  poll = find_poll(poll_id)
+  halt(400, { message: "poll #{poll_id} not found" }.to_s) unless poll
+
+  vote = (poll['latest_votes_by_option'].values.flatten + poll['latest_answers'])
+         .detect { |v| v['id'] == vote_id }
+  halt(400, { message: "vote #{vote_id} not found" }.to_s) unless vote
+
+  if vote['is_answer']
+    poll['latest_answers'].delete(vote)
+    poll['answers_count'] -= 1
+  else
+    option_votes = poll['latest_votes_by_option'][vote['option_id']]
+    option_votes&.delete(vote)
+    poll['vote_counts_by_option'][vote['option_id']] = [(poll['vote_counts_by_option'][vote['option_id']] || 1) - 1, 0].max
+    poll['vote_count'] = [poll['vote_count'] - 1, 0].max
+  end
+  poll['own_votes'].delete_if { |own| own['id'] == vote_id }
+  poll['updated_at'] = unique_date
+
+  broadcast_poll_event(
+    type: PollEventType.vote_removed,
+    poll: poll,
+    poll_vote: vote,
+    message: find_message_by_id(message_id)
+  )
+  { vote: vote, duration: '7.11ms' }.to_s
+end
+
+# Drops every non-answer vote of `user`, used to model `enforce_unique_vote`:
+# the backend replaces the previous vote and reports the cast as `poll.vote_changed`.
+def remove_user_votes(poll:, user:)
+  removed = []
+  poll['latest_votes_by_option'].each do |option_id, votes|
+    votes.delete_if do |vote|
+      next false unless vote['user_id'] == user['id']
+
+      removed << vote
+      poll['vote_counts_by_option'][option_id] = [(poll['vote_counts_by_option'][option_id] || 1) - 1, 0].max
+      poll['vote_count'] = [poll['vote_count'] - 1, 0].max
+      true
+    end
+  end
+  poll['own_votes'].delete_if { |vote| removed.any? { |removed_vote| removed_vote['id'] == vote['id'] } }
+  removed
+end
+
+# Clients map every poll event through `cid`, which only exists once a message
+# carries the poll, so the broadcast is skipped while the poll has no message.
+def broadcast_poll_event(type:, poll:, poll_vote: nil, message: nil)
+  message ||= find_poll_message(poll['id'])
+  return unless message
+
+  event = {
+    'type' => type,
+    'created_at' => unique_date,
+    'cid' => message['cid'],
+    'channel_type' => 'messaging',
+    'channel_id' => message['channel_id'],
+    'message_id' => message['id'],
+    'poll' => poll
+  }
+  if poll_vote
+    event['poll_vote'] = poll_vote
+    event['user'] = poll_vote['user']
+  end
+  broadcast_event(event)
+end

--- a/src/robots/chat.rb
+++ b/src/robots/chat.rb
@@ -19,6 +19,7 @@ post '/mock' do
   $sync_events = []
   $channel_list['channels'] = []
   $reminders = []
+  $polls = []
   $user_mutes = []
   $channel_mutes = []
   $blocked_users = []

--- a/src/robots/participant.rb
+++ b/src/robots/participant.rb
@@ -271,6 +271,37 @@ post '/participant/reaction' do
   ''
 end
 
+###### POLLS ######
+
+### Parameters
+# `option`: String - The text of the poll option to vote for
+# `answer`: String - Pass this param to add an answer (comment) instead of an option vote
+
+post '/participant/poll_vote' do
+  message = $message_list.reverse.detect { |msg| msg['poll'] }
+  halt(400, { message: 'no message with a poll' }.to_s) unless message
+
+  poll = message['poll']
+  vote_data =
+    if params[:answer]
+      { 'answer_text' => params[:answer] }
+    else
+      option = poll['options'].detect { |opt| opt['text'] == params[:option] }
+      halt(400, { message: "option #{params[:option]} not found" }.to_s) unless option
+
+      { 'option_id' => option['id'] }
+    end
+
+  cast_poll_vote(
+    message_id: message['id'],
+    poll_id: poll['id'],
+    vote_data: vote_data,
+    user: Participant.user
+  )
+  sync_channels
+  ''
+end
+
 ###### EVENTS ######
 
 ### Parameters

--- a/src/server.rb
+++ b/src/server.rb
@@ -19,6 +19,7 @@ require_relative 'helpers/reactions'
 require_relative 'helpers/channels'
 require_relative 'helpers/reads'
 require_relative 'helpers/moderation'
+require_relative 'helpers/polls'
 require_relative 'helpers/reminders'
 require_relative 'helpers/threads'
 require_relative 'robots/chat'
@@ -28,6 +29,7 @@ $ws = nil
 $message_list = []
 $sync_events = []
 $reminders = []
+$polls = []
 $user_mutes = []
 $channel_mutes = []
 $blocked_users = []

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -311,76 +311,87 @@ delete '/messages/:message_id/reminders' do
   delete_reminder(message_id: params[:message_id])
 end
 
-# Create poll
-post '/polls' do
-  create_poll(request_body: request.body.read)
+# iOS sends every poll path under /api/v2 while Android and Flutter send it unprefixed,
+# so each poll route is registered under both spellings, like the v2 upload routes above.
+['/polls', '/api/v2/polls'].each do |polls|
+  # Create poll
+  post polls do
+    create_poll(request_body: request.body.read)
+  end
+
+  # Update poll
+  put polls do
+    update_poll(request_body: request.body.read)
+  end
+
+  # Query polls
+  post "#{polls}/query" do
+    { polls: $polls, duration: '7.11ms' }.to_s
+  end
+
+  # Get poll
+  get "#{polls}/:poll_id" do
+    poll = find_poll(params[:poll_id])
+    halt(400, { message: "poll #{params[:poll_id]} not found" }.to_s) unless poll
+
+    { poll: poll, duration: '7.11ms' }.to_s
+  end
+
+  # Partially update poll
+  patch "#{polls}/:poll_id" do
+    partial_update_poll(poll_id: params[:poll_id], request_body: request.body.read)
+  end
+
+  # Delete poll
+  delete "#{polls}/:poll_id" do
+    delete_poll(poll_id: params[:poll_id])
+  end
+
+  # Create poll option
+  post "#{polls}/:poll_id/options" do
+    create_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
+  end
+
+  # Update poll option
+  put "#{polls}/:poll_id/options" do
+    update_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
+  end
+
+  # Get poll option
+  get "#{polls}/:poll_id/options/:option_id" do
+    get_poll_option(poll_id: params[:poll_id], option_id: params[:option_id])
+  end
+
+  # Delete poll option
+  delete "#{polls}/:poll_id/options/:option_id" do
+    delete_poll_option(poll_id: params[:poll_id], option_id: params[:option_id])
+  end
+
+  # Query poll votes
+  post "#{polls}/:poll_id/votes" do
+    query_poll_votes(poll_id: params[:poll_id], request_body: request.body.read)
+  end
 end
 
-# Update poll
-put '/polls' do
-  update_poll(request_body: request.body.read)
-end
+['/messages', '/api/v2/chat/messages'].each do |messages|
+  # Cast poll vote or answer
+  post "#{messages}/:message_id/polls/:poll_id/vote" do
+    json = JSON.parse(request.body.read)
+    cast_poll_vote(
+      message_id: params[:message_id],
+      poll_id: params[:poll_id],
+      vote_data: json['vote'] || {}
+    )
+  end
 
-# Query polls
-post '/polls/query' do
-  { polls: $polls, duration: '7.11ms' }.to_s
-end
-
-# Get poll
-get '/polls/:poll_id' do
-  poll = find_poll(params[:poll_id])
-  halt(400, { message: "poll #{params[:poll_id]} not found" }.to_s) unless poll
-
-  { poll: poll, duration: '7.11ms' }.to_s
-end
-
-# Partially update poll
-patch '/polls/:poll_id' do
-  partial_update_poll(poll_id: params[:poll_id], request_body: request.body.read)
-end
-
-# Delete poll
-delete '/polls/:poll_id' do
-  delete_poll(poll_id: params[:poll_id])
-end
-
-# Create poll option
-post '/polls/:poll_id/options' do
-  create_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
-end
-
-# Update poll option
-put '/polls/:poll_id/options' do
-  update_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
-end
-
-# Delete poll option
-delete '/polls/:poll_id/options/:option_id' do
-  delete_poll_option(poll_id: params[:poll_id], option_id: params[:option_id])
-end
-
-# Query poll votes
-post '/polls/:poll_id/votes' do
-  query_poll_votes(poll_id: params[:poll_id], request_body: request.body.read)
-end
-
-# Cast poll vote or answer
-post '/messages/:message_id/polls/:poll_id/vote' do
-  json = JSON.parse(request.body.read)
-  cast_poll_vote(
-    message_id: params[:message_id],
-    poll_id: params[:poll_id],
-    vote_data: json['vote'] || {}
-  )
-end
-
-# Remove poll vote
-delete '/messages/:message_id/polls/:poll_id/vote/:vote_id' do
-  remove_poll_vote(
-    message_id: params[:message_id],
-    poll_id: params[:poll_id],
-    vote_id: params[:vote_id]
-  )
+  # Remove poll vote
+  delete "#{messages}/:message_id/polls/:poll_id/vote/:vote_id" do
+    remove_poll_vote(
+      message_id: params[:message_id],
+      poll_id: params[:poll_id],
+      vote_id: params[:vote_id]
+    )
+  end
 end
 
 # Get link preview details

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -311,6 +311,78 @@ delete '/messages/:message_id/reminders' do
   delete_reminder(message_id: params[:message_id])
 end
 
+# Create poll
+post '/polls' do
+  create_poll(request_body: request.body.read)
+end
+
+# Update poll
+put '/polls' do
+  update_poll(request_body: request.body.read)
+end
+
+# Query polls
+post '/polls/query' do
+  { polls: $polls, duration: '7.11ms' }.to_s
+end
+
+# Get poll
+get '/polls/:poll_id' do
+  poll = find_poll(params[:poll_id])
+  halt(400, { message: "poll #{params[:poll_id]} not found" }.to_s) unless poll
+
+  { poll: poll, duration: '7.11ms' }.to_s
+end
+
+# Partially update poll
+patch '/polls/:poll_id' do
+  partial_update_poll(poll_id: params[:poll_id], request_body: request.body.read)
+end
+
+# Delete poll
+delete '/polls/:poll_id' do
+  delete_poll(poll_id: params[:poll_id])
+end
+
+# Create poll option
+post '/polls/:poll_id/options' do
+  create_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
+end
+
+# Update poll option
+put '/polls/:poll_id/options' do
+  update_poll_option(poll_id: params[:poll_id], request_body: request.body.read)
+end
+
+# Delete poll option
+delete '/polls/:poll_id/options/:option_id' do
+  delete_poll_option(poll_id: params[:poll_id], option_id: params[:option_id])
+end
+
+# Query poll votes
+post '/polls/:poll_id/votes' do
+  query_poll_votes(poll_id: params[:poll_id], request_body: request.body.read)
+end
+
+# Cast poll vote or answer
+post '/messages/:message_id/polls/:poll_id/vote' do
+  json = JSON.parse(request.body.read)
+  cast_poll_vote(
+    message_id: params[:message_id],
+    poll_id: params[:poll_id],
+    vote_data: json['vote'] || {}
+  )
+end
+
+# Remove poll vote
+delete '/messages/:message_id/polls/:poll_id/vote/:vote_id' do
+  remove_poll_vote(
+    message_id: params[:message_id],
+    poll_id: params[:poll_id],
+    vote_id: params[:vote_id]
+  )
+end
+
 # Get link preview details
 get '/og' do
   create_link_preview(params[:url])


### PR DESCRIPTION
### Goal

Add mock server support for polls so the client e2e suites can cover creating a poll and voting. The poll endpoints were not implemented, and unhandled requests return 404, so no poll flow could be tested against the mock.

### Implementation

- Polls live in `$polls` (new `src/helpers/polls.rb`) and are embedded on their message by reference under `poll`, so an in-place poll mutation is visible in every later message list response without re-linking. A message sent with a root-level `poll_id` (clients flatten it onto the message) gets the poll attached.
- New endpoints: poll create, get, full update (PUT), partial update (PATCH, which is also how clients close a poll), delete; option create, update, delete; vote cast and remove under `/messages/{message_id}/polls/{poll_id}/vote`; query polls and query votes.
- Websocket events: `poll.updated`, `poll.closed`, `poll.deleted`, `poll.vote_casted`, `poll.vote_changed` (a vote replaced under `enforce_unique_vote`) and `poll.vote_removed`. Every event carries `cid`, `message_id` and the full poll, and vote events also carry `poll_vote` with its user. This is the set the clients need to route the event to the channel and merge the vote.
- `own_votes` holds only the app user's votes: the poll payload is always serialized from the app user's point of view, and participant votes reach the app user through the vote events. This matches how clients decide the "your vote" state.
- Answers (poll comments) are votes with `is_answer: true`, an `answer_text` and an empty `option_id`, delivered in `latest_answers`.
- New participant robot route `POST /participant/poll_vote` casts a vote on the newest poll message (`option` selects by text) or adds an answer (`answer`) as the second user.

### Testing

- `bundle exec rubocop`: no offenses.
- A scripted flow against a local server (a real websocket client plus HTTP): create, message linking, get, vote, vote change under `enforce_unique_vote`, answer, vote removal, participant vote, option create/update/delete, query votes and polls, close via PATCH, rename via PUT, delete. 66 checks in total, including the response shapes the Android client parses as required fields and the exact websocket event sequence. All green.
- The five new Android `PollsTests` run green locally against this branch (API 35 emulator, per-test data isolation).

### 🔗 Issue Links

[AND-1330](https://linear.app/stream/issue/AND-1330/mock-server-support-and-e2e-coverage-for-polls). Companion Android PR: GetStream/stream-chat-android#6649.

### 🧪 Testing Notes

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/runs/32243367286)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/runs/32242984871) (PollsTests against the review fixes; the [full matrix](https://github.com/GetStream/stream-chat-android/actions/runs/32230526593) covered the rest of the suite)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/runs/32243370178)






