### PR TITLE
Support channel search, a direct message fixture and live moderation state

### DIFF
--- a/src/helpers/channels.rb
+++ b/src/helpers/channels.rb
@@ -42,11 +42,18 @@ def autocomplete_terms(node, field)
   end
 end
 
+def search_query?(filter)
+  autocomplete_terms(filter, 'name').any? || autocomplete_terms(filter, 'member.user.name').any?
+end
+
 def paginate_channel_list(payload: nil)
   payload = JSON.parse(payload) if payload
+  filter = payload && payload['filter_conditions']
   limited_channel_list = $channel_list.dup
-  limited_channel_list['channels'] = queried_channels(payload && payload['filter_conditions'])
-  return limited_channel_list.to_s if payload.nil? || payload['limit'].nil?
+  limited_channel_list['channels'] = queried_channels(filter)
+  # A search query is never sliced and leaves the pagination flag alone, so
+  # channel search cannot disturb the paging state of the unfiltered queries.
+  return limited_channel_list.to_s if payload.nil? || payload['limit'].nil? || search_query?(filter)
 
   channels = limited_channel_list['channels'] || []
   channel_count = channels.count - 1

--- a/src/helpers/channels.rb
+++ b/src/helpers/channels.rb
@@ -7,11 +7,47 @@ def sync_channels
   $channel_list.to_s
 end
 
+# The backend excludes hidden channels from a query by default and matches
+# `$autocomplete` search conditions on `name` and `member.user.name`. The tests
+# only need enough of that to prove a channel is matched by its name, so every
+# other condition in the filter keeps being ignored.
+def queried_channels(filter)
+  channels = ($channel_list['channels'] || []).reject { |c| c['channel']['hidden'] }
+  name_terms = autocomplete_terms(filter, 'name')
+  member_terms = autocomplete_terms(filter, 'member.user.name')
+  return channels if name_terms.empty? && member_terms.empty?
+
+  channels.select do |channel|
+    name = channel['channel']['name'].to_s.downcase
+    member_names = (channel['members'] || []).map { |m| m.dig('user', 'name').to_s.downcase }
+    name_terms.any? { |term| name.include?(term.downcase) } ||
+      member_terms.any? { |term| member_names.any? { |n| n.include?(term.downcase) } }
+  end
+end
+
+def autocomplete_terms(node, field)
+  case node
+  when Array
+    node.flat_map { |item| autocomplete_terms(item, field) }
+  when Hash
+    node.flat_map do |key, value|
+      if key == field && value.kind_of?(Hash) && value['$autocomplete']
+        [value['$autocomplete']]
+      else
+        autocomplete_terms(value, field)
+      end
+    end
+  else
+    []
+  end
+end
+
 def paginate_channel_list(payload: nil)
   payload = JSON.parse(payload) if payload
-  return $channel_list.to_s if payload.nil? || payload['limit'].nil?
-
   limited_channel_list = $channel_list.dup
+  limited_channel_list['channels'] = queried_channels(payload && payload['filter_conditions'])
+  return limited_channel_list.to_s if payload.nil? || payload['limit'].nil?
+
   channels = limited_channel_list['channels'] || []
   channel_count = channels.count - 1
   limit = payload['limit'].to_i

--- a/src/helpers/moderation.rb
+++ b/src/helpers/moderation.rb
@@ -4,10 +4,18 @@
 # need since nothing queries flags.
 
 def own_user
-  user = current_user.dup
-  user['mutes'] = $user_mutes
-  user['channel_mutes'] = $channel_mutes
-  user
+  current_user.dup.merge(live_own_user_state)
+end
+
+# The client applies every own-user push as a full update, so any payload that
+# carries `me` (the health check included) has to embed the live moderation
+# state or it wipes what a mute or block endpoint just changed.
+def live_own_user_state
+  {
+    'mutes' => $user_mutes,
+    'channel_mutes' => $channel_mutes,
+    'blocked_user_ids' => $blocked_users.map { |b| b['blocked_user_id'] }
+  }
 end
 
 def find_user_by_id(user_id)
@@ -94,6 +102,7 @@ def block_user(blocked_user_id:)
     'created_at' => timestamp
   }
   $blocked_users << block
+  hide_direct_message_channels(blocked_user_id)
   {
     blocked_by_user_id: current_user['id'],
     blocked_user_id: blocked_user_id,
@@ -104,5 +113,51 @@ end
 
 def unblock_user(blocked_user_id:)
   $blocked_users.delete_if { |b| b['blocked_user_id'] == blocked_user_id }
+  show_direct_message_channels(blocked_user_id)
   { duration: '7.11ms' }.to_s
+end
+
+# The backend hides every channel whose exact members are the blocking and the
+# blocked user, and unhides those same channels on unblock. The block remembers
+# which channels it hid so an unblock does not surface a channel the user had
+# hidden independently.
+def hide_direct_message_channels(blocked_user_id)
+  hidden_cids = []
+  channels_with_exact_members(blocked_user_id).each do |channel|
+    next if channel['channel']['hidden']
+
+    channel['channel']['hidden'] = true
+    hidden_cids << channel['channel']['cid']
+    send_channel_visibility_ws(channel: channel, type: 'channel.hidden')
+  end
+  $block_hidden_channels[blocked_user_id] = hidden_cids
+end
+
+def show_direct_message_channels(blocked_user_id)
+  ($block_hidden_channels.delete(blocked_user_id) || []).each do |cid|
+    channel = find_channel_by_id(cid.split(':').last)
+    next unless channel && channel['channel']['hidden']
+
+    channel['channel']['hidden'] = false
+    send_channel_visibility_ws(channel: channel, type: 'channel.visible')
+  end
+end
+
+def channels_with_exact_members(user_id)
+  expected_ids = [current_user['id'], user_id].sort
+  $channel_list['channels'].select do |channel|
+    (channel['members'] || []).map { |m| m['user_id'] }.sort == expected_ids
+  end
+end
+
+def send_channel_visibility_ws(channel:, type:)
+  ws_response = Mocks.event_ws
+  ws_response['type'] = type
+  ws_response['cid'] = channel['channel']['cid']
+  ws_response['channel_id'] = channel['channel']['id']
+  ws_response['created_at'] = unique_date
+  ws_response['user'] = current_user
+  ws_response['channel'] = channel['channel']
+  ws_response['clear_history'] = false if type == 'channel.hidden'
+  broadcast_event(ws_response)
 end

--- a/src/helpers/moderation.rb
+++ b/src/helpers/moderation.rb
@@ -130,7 +130,9 @@ def hide_direct_message_channels(blocked_user_id)
     hidden_cids << channel['channel']['cid']
     send_channel_visibility_ws(channel: channel, type: 'channel.hidden')
   end
-  $block_hidden_channels[blocked_user_id] = hidden_cids
+  # A repeated block finds the channels already hidden and collects nothing, so
+  # union with what earlier blocks recorded instead of overwriting it.
+  $block_hidden_channels[blocked_user_id] = ($block_hidden_channels[blocked_user_id] || []) | hidden_cids
 end
 
 def show_direct_message_channels(blocked_user_id)

--- a/src/robots/chat.rb
+++ b/src/robots/chat.rb
@@ -5,8 +5,15 @@
 # `attachments`: Boolean - Attachments included in every message. Default false
 # `messages_text`: String - Text for all the channel messages
 # `replies_text`: String - Text for all the thread messages
+# `dm`: Boolean - Also seed a direct-message channel between the app user and
+#                 the participant: exactly two members, a member-based cid and
+#                 no name, which is how the backend models 1:1 channels. Default false
+# `channel_names`: String - Comma-separated names for the first channels, in channel
+#                  order ("1", "2", ...). Channels without an entry keep their
+#                  positional name. Lets a test seed a name it can search for
 post '/mock' do
   channels_count = params[:channels].to_i || 1
+  channel_names = (params[:channel_names] || '').split(',')
   messages_count = params[:messages].to_i || 0
   replies_count = params[:replies].to_i || 0
 
@@ -23,10 +30,11 @@ post '/mock' do
   $user_mutes = []
   $channel_mutes = []
   $blocked_users = []
+  $block_hidden_channels = {}
 
   channels_count.downto(1) do |i|
     channel_id = SecureRandom.uuid
-    channel_name = i.to_s
+    channel_name = channel_names[i - 1] || i.to_s
     $current_channel_id = channel_id if i == 1
     channel_timestamp = update_date(timestamp: timestamp, minus_seconds: (i * 600) + 1_000_000)
     channel_template = Mocks.channels['channels'].first
@@ -43,6 +51,25 @@ post '/mock' do
     channel_template['read'] = []
     seed_read_state(channel: channel_template, user: current_user, last_read: timestamp)
     $channel_list['channels'] << channel_template
+  end
+
+  if params[:dm] == 'true'
+    dm_id = "!members-#{SecureRandom.uuid}"
+    dm_timestamp = update_date(timestamp: timestamp, minus_seconds: ((channels_count + 1) * 600) + 1_000_000)
+    dm_channel = Mocks.channels['channels'].first
+    dm_channel['channel']['id'] = dm_id
+    dm_channel['channel']['cid'] = "messaging:#{dm_id}"
+    dm_channel['channel'].delete('name')
+    dm_channel['channel']['last_message_at'] = dm_timestamp
+    dm_channel['channel']['created_at'] = dm_timestamp
+    dm_channel['channel']['updated_at'] = dm_timestamp
+    dm_channel['members'] = dm_channel['members'].select do |member|
+      [current_user['id'], Participant.user['id']].include?(member['user_id'])
+    end
+    dm_channel['channel']['member_count'] = dm_channel['members'].count
+    dm_channel['read'] = []
+    seed_read_state(channel: dm_channel, user: current_user, last_read: timestamp)
+    $channel_list['channels'] << dm_channel
   end
 
   $channel_list['channels'].each do |channel|

--- a/src/server.rb
+++ b/src/server.rb
@@ -33,6 +33,7 @@ $polls = []
 $user_mutes = []
 $channel_mutes = []
 $blocked_users = []
+$block_hidden_channels = {}
 $channel_list = Mocks.channels
 $current_channel_id = Mocks.event_ws['channel_id']
 $health_check = Mocks.health_check.to_s
@@ -56,9 +57,15 @@ get '/stop' do
   end
 end
 
+# The health check is rebuilt on every send so its `me` carries the live
+# moderation state. The static payload would reset the own user, wiping any
+# mute or block a few seconds after the endpoint applied it. Token-error
+# payloads set by jwt.rb pass through untouched.
 def send_health_check
-  $ws&.send($health_check)
-  $ws&.close(1000) if JSON.parse($health_check)['type'] == 'connection.error'
+  payload = JSON.parse($health_check)
+  payload['me'] = payload['me'].merge(live_own_user_state) if payload['type'] == 'health.check' && payload['me']
+  $ws&.send(payload.to_s)
+  $ws&.close(1000) if payload['type'] == 'connection.error'
 end
 
 Thread.new do

--- a/src/server/endpoints.rb
+++ b/src/server/endpoints.rb
@@ -36,10 +36,12 @@ get '/channels' do
   paginate_channel_list(payload: params[:payload])
 end
 
-# Show channel list (post request)
+# Show channel list (post request). Android sends the query as the request body,
+# while iOS sends it as the `payload` query parameter.
 post '/channels' do
   sync_channels
-  paginate_channel_list(payload: params[:payload])
+  body = request.body.read
+  paginate_channel_list(payload: params[:payload] || (body unless body.empty?))
 end
 
 # Show channel info


### PR DESCRIPTION
### 🔗 Issue Links

[AND-1359](https://linear.app/stream/issue/AND-1359/e2e-coverage-for-channel-search-direct-messages-and-the-moderation)

### 📝 Summary

Adds the mock server support that the missing Android e2e coverage needs: channel search, blocking in a direct message channel, and stable mute and block state.

- **The health check now carries the live own user.** The payload was built once at startup, so its `me` had an empty `mutes`, an empty `channel_mutes` and no blocked users, and every push reset the state a mute or block endpoint had just applied. The client applies each own-user push as a full update, which is why the mute and block state tests only passed when the assertion landed inside that window. The health check is rebuilt on every send with the live `mutes`, `channel_mutes` and `blocked_user_ids`. The token error payloads set by `jwt.rb` pass through unchanged.
- **The channel query now honors the search filter.** `POST /channels` read only the `payload` query parameter, which is how iOS sends the query; Android sends it as the request body, so the body is now read as well. The query drops hidden channels and applies the `$autocomplete` conditions on `name` and `member.user.name`, which is the filter the SDKs send for channel search. Every other condition keeps being ignored.
- **Blocking hides the shared 1:1 channels.** The backend hides every channel whose exact members are the blocking and the blocked user, sends `channel.hidden` for each, and shows those same channels again with `channel.visible` on unblock. The mock now does the same, and remembers which channels each block hid so an unblock does not surface a channel that was hidden independently.
- **`/mock` gains two parameters.** `dm=true` seeds a direct message channel between the app user and the participant, with exactly two members, a member-based cid and no name, which is how the backend models 1:1 channels. `channel_names` gives the seeded channels searchable names. Both default off, so existing test runs see an unchanged fixture.

### 🧪 Testing Notes

Verified locally on an API 35 emulator against this branch, with the Android tests from the companion SDK PR:

- the new channel search and direct message block tests pass, including the channel disappearing from the channel list on block and returning on unblock
- the six mute and block state tests removed from GetStream/stream-chat-android#6610 pass again
- regressions pass: message search, the giphy ephemeral cancel, the channel list preview tests, and all 11 `AuthTests`, which exercise the token error health check payloads

Please verify the E2E test runs:
- [x] [iOS](https://github.com/GetStream/stream-chat-swift/actions/runs/32355254260)
- [x] [Android](https://github.com/GetStream/stream-chat-android/actions/runs/32355250900)
- [x] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/runs/32355256830)



