### PR TITLE
Send duration on the link preview response

### DIFF
--- a/src/helpers/messages.rb
+++ b/src/helpers/messages.rb
@@ -454,15 +454,17 @@ def mock_attachments(params)
 end
 
 def create_link_preview(url)
-  if url.include?('youtube')
-    Mocks.youtube_link['message']['attachments'].first.to_s
-  elsif url.include?('unsplash')
-    Mocks.unsplash_link['message']['attachments'].first.to_s
-  elsif url.include?('giphy')
-    Mocks.giphy_link['message']['attachments'].first.to_s
-  else
-    ''
-  end
+  attachment =
+    if url.include?('youtube')
+      Mocks.youtube_link['message']['attachments'].first
+    elsif url.include?('unsplash')
+      Mocks.unsplash_link['message']['attachments'].first
+    elsif url.include?('giphy')
+      Mocks.giphy_link['message']['attachments'].first
+    end
+  return '' if attachment.nil?
+
+  attachment.merge('duration' => '7.11ms').to_s
 end
 
 def paginate_message_list(params:, request_body:)


### PR DESCRIPTION
### Goal

`GET /og` returns a recorded message attachment, which carries no `duration`. The generated
`GetOGResponse` the Android SDK is adopting declares `duration` as required and non-null, so the response
no longer parses and the link preview tests fail.

### Implementation

Merge `duration` into the attachment when answering `/og`, rather than adding it to the recorded
attachments in `src/jsons`, since a message attachment does not carry response metadata and those files
are also served as message payloads.

### Testing

`HyperLinksTests` covers the unsplash and youtube previews, which are the two paths this affects.


Please verify the E2E test runs:
- [ ] [iOS](https://github.com/GetStream/stream-chat-swift/actions/workflows/cron-checks.yml?query=event%3Aworkflow_dispatch)
  - [run 32465437036](https://github.com/GetStream/stream-chat-swift/actions/runs/32465437036)
- [ ] [Android](https://github.com/GetStream/stream-chat-android/actions/workflows/e2e-test-cron.yml?query=event%3Aworkflow_dispatch)
  - [run 32465439801](https://github.com/GetStream/stream-chat-android/actions/runs/32465439801)
- [ ] [Flutter](https://github.com/GetStream/stream-chat-flutter/actions/workflows/e2e_test_cron.yml?query=event%3Aworkflow_dispatch)
  - [run 32465442735](https://github.com/GetStream/stream-chat-flutter/actions/runs/32465442735)
